### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/937/421166937.geojson
+++ b/data/421/166/937/421166937.geojson
@@ -329,6 +329,9 @@
     },
     "wof:country":"SO",
     "wof:created":1459008708,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"b3cc6d1ba7b473a97aa5fd3ade7f88d4",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
         }
     ],
     "wof:id":421166937,
-    "wof:lastmodified":1566649648,
+    "wof:lastmodified":1582332258,
     "wof:name":"Boosaaso",
     "wof:parent_id":1108757801,
     "wof:placetype":"locality",

--- a/data/421/180/189/421180189.geojson
+++ b/data/421/180/189/421180189.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"SO",
     "wof:created":1459009247,
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"49cad63ec6007fc1a94cc7d047ad7d70",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421180189,
-    "wof:lastmodified":1527716237,
+    "wof:lastmodified":1582332258,
     "wof:name":"Somalia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/323/79/85632379.geojson
+++ b/data/856/323/79/85632379.geojson
@@ -958,6 +958,10 @@
     },
     "wof:country":"SO",
     "wof:country_alpha3":"SOM",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"fe17ff694ae1b2c05e1dfd64fc108b42",
     "wof:hierarchy":[
         {
@@ -974,7 +978,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649322,
+    "wof:lastmodified":1582332251,
     "wof:name":"Somalia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/772/35/85677235.geojson
+++ b/data/856/772/35/85677235.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Bari, Somalia"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7b1240cfcdc730349ad545a072baf96",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649323,
+    "wof:lastmodified":1582332252,
     "wof:name":"Bari",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/41/85677241.geojson
+++ b/data/856/772/41/85677241.geojson
@@ -269,6 +269,9 @@
         "wk:page":"Bakool"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"398e73f1426e4228c3b4cb69b440f9ae",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649326,
+    "wof:lastmodified":1582332253,
     "wof:name":"Bakool",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/45/85677245.geojson
+++ b/data/856/772/45/85677245.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Bay, Somalia"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58bd85b04c8b6d7b3864368ae5f6b036",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649324,
+    "wof:lastmodified":1582332252,
     "wof:name":"Bay",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/49/85677249.geojson
+++ b/data/856/772/49/85677249.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Gedo"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c00facead61f005209b4f382e828d2c",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649327,
+    "wof:lastmodified":1582332253,
     "wof:name":"Gedo",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/53/85677253.geojson
+++ b/data/856/772/53/85677253.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Middle Juba"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc75a743d206fde6155d76f73446c4db",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649325,
+    "wof:lastmodified":1582332253,
     "wof:name":"Juba Dhexe",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/59/85677259.geojson
+++ b/data/856/772/59/85677259.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Lower Shebelle"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14de71cfb2e74d49a013f05aada76b57",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649323,
+    "wof:lastmodified":1582332252,
     "wof:name":"Shabeellaha Hoose",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/63/85677263.geojson
+++ b/data/856/772/63/85677263.geojson
@@ -281,6 +281,9 @@
         890449737
     ],
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cffc609c86274b2a06f01584d50d9697",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649326,
+    "wof:lastmodified":1582332253,
     "wof:name":"Banaadir",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/67/85677267.geojson
+++ b/data/856/772/67/85677267.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Galguduud"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8b59a8e537ef73e70f816ebfdf0cc09",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649324,
+    "wof:lastmodified":1582332252,
     "wof:name":"Galguduud",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/69/85677269.geojson
+++ b/data/856/772/69/85677269.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Hiran, Somalia"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5a3cf5358f8e602c357c85e050601bc",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649323,
+    "wof:lastmodified":1582332252,
     "wof:name":"Hiiraan",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/75/85677275.geojson
+++ b/data/856/772/75/85677275.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Middle Shebelle"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48a3ac690d67d474c709c245b5014b5a",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649325,
+    "wof:lastmodified":1582332253,
     "wof:name":"Shabeellaha Dhexe",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/79/85677279.geojson
+++ b/data/856/772/79/85677279.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Mudug"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"373ec5ca054c85cce9c14496f8114033",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649326,
+    "wof:lastmodified":1582332253,
     "wof:name":"Mudug",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/83/85677283.geojson
+++ b/data/856/772/83/85677283.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Nugal, Somalia"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e3c9c2645323e5fa60d6c108b9e6bf0",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649326,
+    "wof:lastmodified":1582332253,
     "wof:name":"Nugaal",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/87/85677287.geojson
+++ b/data/856/772/87/85677287.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Lower Juba"
     },
     "wof:country":"SO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74811320417ee2e2e8ac35b528b7497b",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566649325,
+    "wof:lastmodified":1582332252,
     "wof:name":"Jubbada Hoose",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/890/449/737/890449737.geojson
+++ b/data/890/449/737/890449737.geojson
@@ -577,6 +577,9 @@
     ],
     "wof:country":"SO",
     "wof:created":1469052706,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"e6712e127d555d9cfd04d734a6cadb27",
     "wof:hierarchy":[
         {
@@ -588,7 +591,7 @@
         }
     ],
     "wof:id":890449737,
-    "wof:lastmodified":1566649652,
+    "wof:lastmodified":1582332258,
     "wof:name":"Mogadishu",
     "wof:parent_id":1108757805,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.