### PR TITLE
so concordances, placetype local, and more

### DIFF
--- a/data/110/875/777/1/1108757771.geojson
+++ b/data/110/875/777/1/1108757771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.324871,
-    "geom:area_square_m":4009382857.56433,
+    "geom:area_square_m":4009382770.601982,
     "geom:bbox":"46.063659,3.156908,47.036371,3.891415",
     "geom:latitude":3.548747,
     "geom:longitude":46.545741,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SD.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308100,
-    "wof:geomhash":"7171e7d911821b0c86ee561856ea74ec",
+    "wof:geomhash":"5134021f5d0d128702914c07639f428c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757771,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Adan Yabaal",
     "wof:parent_id":85677275,
     "wof:placetype":"county",

--- a/data/110/875/777/3/1108757773.geojson
+++ b/data/110/875/777/3/1108757773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.173353,
-    "geom:area_square_m":26871896327.370953,
+    "geom:area_square_m":26871896327.370434,
     "geom:bbox":"40.994373,-0.191364257653,42.7283039779,1.32043017948",
     "geom:latitude":0.59097,
     "geom:longitude":41.785089,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JH.AF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308101,
-    "wof:geomhash":"3c8a6c5427e1c97455ed7f79149ec5c1",
+    "wof:geomhash":"980bf6a85f2b48c0d50e7f69247b66a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757773,
-    "wof:lastmodified":1566649559,
+    "wof:lastmodified":1695886424,
     "wof:name":"Afmadow",
     "wof:parent_id":85677287,
     "wof:placetype":"county",

--- a/data/110/875/777/5/1108757775.geojson
+++ b/data/110/875/777/5/1108757775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.240822,
-    "geom:area_square_m":15332324105.071903,
+    "geom:area_square_m":15332325265.970764,
     "geom:bbox":"40.994374,1.231853,42.542152,2.940058",
     "geom:latitude":2.101398,
     "geom:longitude":41.70577,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GE.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308103,
-    "wof:geomhash":"3013edf8e9cd25bbafaf5ca8accd69aa",
+    "wof:geomhash":"fc7d8e0436604aa12540859d6c2d58e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757775,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Baardheere",
     "wof:parent_id":85677249,
     "wof:placetype":"county",

--- a/data/110/875/777/7/1108757777.geojson
+++ b/data/110/875/777/7/1108757777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.343697,
-    "geom:area_square_m":4245853923.39713,
+    "geom:area_square_m":4245853896.001122,
     "geom:bbox":"45.330299,2.151314,46.133062,2.760763",
     "geom:latitude":2.488654,
     "geom:longitude":45.659396,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SD.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308104,
-    "wof:geomhash":"9469300e44683e55b52bb1d5c4c8c076",
+    "wof:geomhash":"7c8b08864518f8b726a573514f6d72a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757777,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Balcad",
     "wof:parent_id":85677275,
     "wof:placetype":"county",

--- a/data/110/875/777/9/1108757779.geojson
+++ b/data/110/875/777/9/1108757779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.93203,
-    "geom:area_square_m":11375250166.046265,
+    "geom:area_square_m":11375250429.108864,
     "geom:bbox":"49.888855,8.324998,50.877854,9.92126",
     "geom:latitude":9.229368,
     "geom:longitude":50.329538,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BR.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308105,
-    "wof:geomhash":"b2cfc0f956255e33b05bf2fdcd6f1ec9",
+    "wof:geomhash":"e4590769ded805513335cd21c8d74ae5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108757779,
-    "wof:lastmodified":1636497584,
+    "wof:lastmodified":1695886738,
     "wof:name":"Bandarbeyla",
     "wof:parent_id":85677235,
     "wof:placetype":"county",

--- a/data/110/875/778/3/1108757783.geojson
+++ b/data/110/875/778/3/1108757783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.472239,
-    "geom:area_square_m":5830792016.767433,
+    "geom:area_square_m":5830791552.05051,
     "geom:bbox":"45.939899,2.558721,46.754873,3.531906",
     "geom:latitude":3.090775,
     "geom:longitude":46.26315,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SD.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308106,
-    "wof:geomhash":"6e65e80195bd09adf9358d44d42ed549",
+    "wof:geomhash":"0a234b3b3239b3b0ecdf5e3d13cd902e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757783,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Cadale",
     "wof:parent_id":85677275,
     "wof:placetype":"county",

--- a/data/110/875/778/5/1108757785.geojson
+++ b/data/110/875/778/5/1108757785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.839594,
-    "geom:area_square_m":10355712273.338009,
+    "geom:area_square_m":10355711781.174232,
     "geom:bbox":"46.389781,3.470957,47.827847,4.494122",
     "geom:latitude":4.051872,
     "geom:longitude":47.048384,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GA.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308107,
-    "wof:geomhash":"4ef2035599d35769a168989eea24b26c",
+    "wof:geomhash":"7bff6eb9f5fe982ab018d5ee4956935b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757785,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886481,
     "wof:name":"Ceel Dheer",
     "wof:parent_id":85677267,
     "wof:placetype":"county",

--- a/data/110/875/778/7/1108757787.geojson
+++ b/data/110/875/778/7/1108757787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.633718,
-    "geom:area_square_m":7827394321.056793,
+    "geom:area_square_m":7827393403.65416,
     "geom:bbox":"40.994374,2.299201,41.970395,3.144054",
     "geom:latitude":2.679094,
     "geom:longitude":41.44484,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GE.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308109,
-    "wof:geomhash":"239bd4ce3264fe7e7dbb79ea257f8901",
+    "wof:geomhash":"ab2e0d0ff13bda1cdeab7c06daa54382",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757787,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886481,
     "wof:name":"Ceel Waaq",
     "wof:parent_id":85677249,
     "wof:placetype":"county",

--- a/data/110/875/779/1/1108757791.geojson
+++ b/data/110/875/779/1/1108757791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.760239,
-    "geom:area_square_m":9306745718.430752,
+    "geom:area_square_m":9306745332.081902,
     "geom:bbox":"49.054388,7.40489,50.172269,8.685941",
     "geom:latitude":8.094209,
     "geom:longitude":49.564745,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"SO.NU.EY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308111,
-    "wof:geomhash":"27b609a7f452ca563fad98506c120d17",
+    "wof:geomhash":"d1c83192d1473e8cfc7c4036bbaee82d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108757791,
-    "wof:lastmodified":1636497584,
+    "wof:lastmodified":1695886738,
     "wof:name":"Eyl",
     "wof:parent_id":85677283,
     "wof:placetype":"county",

--- a/data/110/875/779/5/1108757795.geojson
+++ b/data/110/875/779/5/1108757795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.415942,
-    "geom:area_square_m":5125185090.567162,
+    "geom:area_square_m":5125184916.495208,
     "geom:bbox":"47.500283,4.334106,48.291315,5.202122",
     "geom:latitude":4.793216,
     "geom:longitude":47.833681,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.MU.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308113,
-    "wof:geomhash":"d7ee4494a06adc41da44ee902ae33be2",
+    "wof:geomhash":"4ca174585596652e484ad566719451ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757795,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886481,
     "wof:name":"Xarardheere",
     "wof:parent_id":85677279,
     "wof:placetype":"county",

--- a/data/110/875/779/7/1108757797.geojson
+++ b/data/110/875/779/7/1108757797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.755602,
-    "geom:area_square_m":9342896559.313034,
+    "geom:area_square_m":9342895854.359673,
     "geom:bbox":"41.293121,-1.013784,42.718618,-0.017303",
     "geom:latitude":-0.37999,
     "geom:longitude":42.009103,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JH.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308114,
-    "wof:geomhash":"2d9fb4f8ab0ad200b972b4de8b4d4948",
+    "wof:geomhash":"eb3f9c95895dac8bbeaaa3ec4d14dacc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757797,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886482,
     "wof:name":"Kismaayo",
     "wof:parent_id":85677287,
     "wof:placetype":"county",

--- a/data/110/875/780/1/1108757801.geojson
+++ b/data/110/875/780/1/1108757801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.653958,
-    "geom:area_square_m":7939772973.096544,
+    "geom:area_square_m":7939772480.641648,
     "geom:bbox":"48.922487,10.356639,49.9109,11.457084",
     "geom:latitude":10.922333,
     "geom:longitude":49.399378,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308115,
-    "wof:geomhash":"2c52798d62e84edeaaf9c6846843cc3d",
+    "wof:geomhash":"84dfaae47fa7c7aef3bfebcda5e65d01",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757801,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886480,
     "wof:name":"Bossaso",
     "wof:parent_id":85677235,
     "wof:placetype":"county",

--- a/data/110/875/780/3/1108757803.geojson
+++ b/data/110/875/780/3/1108757803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.377739,
-    "geom:area_square_m":4574304252.067694,
+    "geom:area_square_m":4574304413.375216,
     "geom:bbox":"50.304799,11.399374,51.292057,11.986111",
     "geom:latitude":11.667038,
     "geom:longitude":50.796836,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BR.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308116,
-    "wof:geomhash":"b0fbf57e1805ac062277b2ac27bce42d",
+    "wof:geomhash":"5336b2f4fa78df360b8fb83b340d107a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108757803,
-    "wof:lastmodified":1636497585,
+    "wof:lastmodified":1695886738,
     "wof:name":"Caluula",
     "wof:parent_id":85677235,
     "wof:placetype":"county",

--- a/data/110/875/780/5/1108757805.geojson
+++ b/data/110/875/780/5/1108757805.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108757805,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886479,
     "wof:name":"Banadir",
     "wof:parent_id":85677263,
     "wof:placetype":"county",

--- a/data/110/875/780/7/1108757807.geojson
+++ b/data/110/875/780/7/1108757807.geojson
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":1108757807,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886425,
     "wof:name":"Afgooye",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/780/9/1108757809.geojson
+++ b/data/110/875/780/9/1108757809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265427,
-    "geom:area_square_m":3281416753.665261,
+    "geom:area_square_m":3281416569.736167,
     "geom:bbox":"43.340476,0.675406,44.492286,1.531446",
     "geom:latitude":1.109986,
     "geom:longitude":43.844329,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SH.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308121,
-    "wof:geomhash":"917bbfde7cf1814c96e231ef57f240a1",
+    "wof:geomhash":"c3f90adfa6b015e6a84ece685a31e60f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757809,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886480,
     "wof:name":"Baraawe",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/781/5/1108757815.geojson
+++ b/data/110/875/781/5/1108757815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.248348,
-    "geom:area_square_m":15322946525.192919,
+    "geom:area_square_m":15322946637.532417,
     "geom:bbox":"46.534873,6.280981,48.532177,7.569219",
     "geom:latitude":6.933782,
     "geom:longitude":47.68208,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SO.MU.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308124,
-    "wof:geomhash":"a625d0004ccea49b3a44ea53ba92dc80",
+    "wof:geomhash":"e1215d4d53e5a99241afe9d390230612",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108757815,
-    "wof:lastmodified":1636497585,
+    "wof:lastmodified":1695886738,
     "wof:name":"Gaalkacyo",
     "wof:parent_id":85677279,
     "wof:placetype":"county",

--- a/data/110/875/782/1/1108757821.geojson
+++ b/data/110/875/782/1/1108757821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.538104,
-    "geom:area_square_m":6619191392.541128,
+    "geom:area_square_m":6619191600.173322,
     "geom:bbox":"45.51676,5.189594,46.670585,6.506704",
     "geom:latitude":5.835799,
     "geom:longitude":46.118874,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GA.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308127,
-    "wof:geomhash":"e9950046bbd008cb1f1cd07f9dbb9907",
+    "wof:geomhash":"2fe9e731acaee883cd4e38320ffc69df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757821,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Cabudwaaq",
     "wof:parent_id":85677267,
     "wof:placetype":"county",

--- a/data/110/875/782/3/1108757823.geojson
+++ b/data/110/875/782/3/1108757823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.618873,
-    "geom:area_square_m":7627038694.14877,
+    "geom:area_square_m":7627039006.166071,
     "geom:bbox":"43.130212,4.428934,44.677533,4.959288",
     "geom:latitude":4.672414,
     "geom:longitude":44.002249,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BK.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308128,
-    "wof:geomhash":"6497fb1c5a6bc75ed61b6bdc6d7157ce",
+    "wof:geomhash":"c2ebac582f028a4da5ffd52e78a2b507",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757823,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886480,
     "wof:name":"Ceel Barde",
     "wof:parent_id":85677241,
     "wof:placetype":"county",

--- a/data/110/875/782/5/1108757825.geojson
+++ b/data/110/875/782/5/1108757825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.304471,
-    "geom:area_square_m":16092485852.071308,
+    "geom:area_square_m":16092485791.628393,
     "geom:bbox":"44.749648,3.200655,46.401171,4.432584",
     "geom:latitude":3.900639,
     "geom:longitude":45.532394,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.HI.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308129,
-    "wof:geomhash":"997fe20d7646a2b1dca18620c43c4b52",
+    "wof:geomhash":"e75ef69900f892a177dbfbf4f6678522",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757825,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886480,
     "wof:name":"Bulo Burto",
     "wof:parent_id":85677269,
     "wof:placetype":"county",

--- a/data/110/875/782/7/1108757827.geojson
+++ b/data/110/875/782/7/1108757827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.088125,
-    "geom:area_square_m":13408355472.439768,
+    "geom:area_square_m":13408355531.380144,
     "geom:bbox":"46.110185,4.234198,47.610105,5.200752",
     "geom:latitude":4.760423,
     "geom:longitude":46.841316,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GA.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308130,
-    "wof:geomhash":"9a594aac5a4a1e039c6e047b16d3dcb2",
+    "wof:geomhash":"667232573147b1e4cf8e9e5c1d799a51",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757827,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886481,
     "wof:name":"Ceel Buur",
     "wof:parent_id":85677267,
     "wof:placetype":"county",

--- a/data/110/875/782/9/1108757829.geojson
+++ b/data/110/875/782/9/1108757829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525735,
-    "geom:area_square_m":6463596309.096949,
+    "geom:area_square_m":6463595576.285505,
     "geom:bbox":"46.503849,5.752969,47.599068,6.537821",
     "geom:latitude":6.131398,
     "geom:longitude":47.036439,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GA.CD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308131,
-    "wof:geomhash":"91a430f37327ceab985066e38f11fdb2",
+    "wof:geomhash":"f99d41a2af54ab76ecd3e64fd7a3cb53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757829,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886480,
     "wof:name":"Cadaado",
     "wof:parent_id":85677267,
     "wof:placetype":"county",

--- a/data/110/875/783/1/1108757831.geojson
+++ b/data/110/875/783/1/1108757831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.034924,
-    "geom:area_square_m":12739303277.881166,
+    "geom:area_square_m":12739303303.223066,
     "geom:bbox":"45.673302,5.030625,47.606118,5.931982",
     "geom:latitude":5.440949,
     "geom:longitude":46.684474,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GA.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308132,
-    "wof:geomhash":"50a9829b7804936c11e79054039befeb",
+    "wof:geomhash":"c354ef3c0dfa22595348b1cf3c676f07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757831,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886481,
     "wof:name":"Dhuusamarreeb",
     "wof:parent_id":85677267,
     "wof:placetype":"county",

--- a/data/110/875/783/3/1108757833.geojson
+++ b/data/110/875/783/3/1108757833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.218556,
-    "geom:area_square_m":15016248059.677658,
+    "geom:area_square_m":15016247864.675089,
     "geom:bbox":"44.59565,4.077512,46.231455,5.490944",
     "geom:latitude":4.727779,
     "geom:longitude":45.380001,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.HI.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308133,
-    "wof:geomhash":"06d951d0402b1bec4c360fd68fdc301b",
+    "wof:geomhash":"3c1047556e6bb19bbf52b31b624deebe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757833,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Belet Weyne",
     "wof:parent_id":85677269,
     "wof:placetype":"county",

--- a/data/110/875/783/7/1108757837.geojson
+++ b/data/110/875/783/7/1108757837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.049198,
-    "geom:area_square_m":12952261231.820089,
+    "geom:area_square_m":12952260945.245632,
     "geom:bbox":"43.099486,2.519104,44.31199,3.92192",
     "geom:latitude":3.265937,
     "geom:longitude":43.639346,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BY.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308134,
-    "wof:geomhash":"57a3952b6571031c3abb89dcfb57d39d",
+    "wof:geomhash":"68be5325d2b63d3ab3a5cfd4dffe63b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757837,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886479,
     "wof:name":"Baydhaba",
     "wof:parent_id":85677245,
     "wof:placetype":"county",

--- a/data/110/875/783/9/1108757839.geojson
+++ b/data/110/875/783/9/1108757839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.790702,
-    "geom:area_square_m":9770476953.285843,
+    "geom:area_square_m":9770477413.559975,
     "geom:bbox":"42.400823,1.461489,43.439458,2.600576",
     "geom:latitude":2.102073,
     "geom:longitude":42.901818,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BY.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308135,
-    "wof:geomhash":"1b00fad38c6dd5480be8071ba2eeb869",
+    "wof:geomhash":"bd534cbc0e934980ab8ee8ac8c51f2fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757839,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886481,
     "wof:name":"Diinsoor",
     "wof:parent_id":85677245,
     "wof:placetype":"county",

--- a/data/110/875/784/1/1108757841.geojson
+++ b/data/110/875/784/1/1108757841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.447337,
-    "geom:area_square_m":5530166752.217118,
+    "geom:area_square_m":5530166970.93832,
     "geom:bbox":"42.142375,0.751957,43.259252,1.511489",
     "geom:latitude":1.19796,
     "geom:longitude":42.740441,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JD.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308137,
-    "wof:geomhash":"779050b67c07d0705ff7e019be49db8c",
+    "wof:geomhash":"3c85aa92dbee1ae2a216438b2adce7d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757841,
-    "wof:lastmodified":1636497584,
+    "wof:lastmodified":1695886738,
     "wof:name":"Bu'aale",
     "wof:parent_id":85677253,
     "wof:placetype":"county",

--- a/data/110/875/784/5/1108757845.geojson
+++ b/data/110/875/784/5/1108757845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.676464,
-    "geom:area_square_m":8351473164.18613,
+    "geom:area_square_m":8351473981.593646,
     "geom:bbox":"41.722367,2.751983,43.102186,3.67931",
     "geom:latitude":3.205833,
     "geom:longitude":42.359062,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GE.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308139,
-    "wof:geomhash":"9756917bcf3802937d76403b6f1ef2fe",
+    "wof:geomhash":"ba7493decf616326de50d920a0ac6db7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757845,
-    "wof:lastmodified":1636497584,
+    "wof:lastmodified":1695886738,
     "wof:name":"Garbahaarey",
     "wof:parent_id":85677249,
     "wof:placetype":"county",

--- a/data/110/875/785/1/1108757851.geojson
+++ b/data/110/875/785/1/1108757851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.071032,
-    "geom:area_square_m":25469030897.350388,
+    "geom:area_square_m":25469030897.351036,
     "geom:bbox":"47.3516377759,5.02883159322,49.1512021621,6.77013635871",
     "geom:latitude":5.971358,
     "geom:longitude":48.202609,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"SO.MU.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308143,
-    "wof:geomhash":"903965e2677224efc5686a9d6e1bbf98",
+    "wof:geomhash":"df4636f6e3633633b2bb22fa0ea392e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108757851,
-    "wof:lastmodified":1566649556,
+    "wof:lastmodified":1695886424,
     "wof:name":"Hobyo",
     "wof:parent_id":85677279,
     "wof:placetype":"county",

--- a/data/110/875/785/5/1108757855.geojson
+++ b/data/110/875/785/5/1108757855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.519088,
-    "geom:area_square_m":18465671953.349678,
+    "geom:area_square_m":18465671953.349518,
     "geom:bbox":"49.562231627,9.80958883017,51.415416718,11.497261235",
     "geom:latitude":10.551569,
     "geom:longitude":50.50668,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BR.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308144,
-    "wof:geomhash":"710e4802a72cc6dc786e3297118d692f",
+    "wof:geomhash":"feddd7e6dd3bbd7506c5418b421fbc6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757855,
-    "wof:lastmodified":1566649556,
+    "wof:lastmodified":1695886424,
     "wof:name":"Iskushuban",
     "wof:parent_id":85677235,
     "wof:placetype":"county",

--- a/data/110/875/785/7/1108757857.geojson
+++ b/data/110/875/785/7/1108757857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175184,
-    "geom:area_square_m":2166171827.903948,
+    "geom:area_square_m":2166172657.859492,
     "geom:bbox":"42.529922,-0.171117,43.186983,0.329135",
     "geom:latitude":0.124194,
     "geom:longitude":42.803067,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JH.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308145,
-    "wof:geomhash":"a45ec2f59c370e3a9ea22e6c72ce46da",
+    "wof:geomhash":"dfd19b4d2daa01cb1d77ea24d4cb57ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757857,
-    "wof:lastmodified":1636497584,
+    "wof:lastmodified":1695886738,
     "wof:name":"Jamaame",
     "wof:parent_id":85677287,
     "wof:placetype":"county",

--- a/data/110/875/785/9/1108757859.geojson
+++ b/data/110/875/785/9/1108757859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.427042,
-    "geom:area_square_m":5280103755.0482,
+    "geom:area_square_m":5280103790.747705,
     "geom:bbox":"42.619359,0.311395,43.520826,1.046381",
     "geom:latitude":0.644501,
     "geom:longitude":43.0567,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JD.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308146,
-    "wof:geomhash":"544ebd2c0608ca05eb10d66eb9c9450e",
+    "wof:geomhash":"98d27733c93a90fbb99020191ea776fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108757859,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886482,
     "wof:name":"Jilib",
     "wof:parent_id":85677253,
     "wof:placetype":"county",

--- a/data/110/875/786/1/1108757861.geojson
+++ b/data/110/875/786/1/1108757861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.377297,
-    "geom:area_square_m":4658971638.113358,
+    "geom:area_square_m":4658971638.113336,
     "geom:bbox":"45.0751240546,2.72193561149,45.9615727434,3.25060048825",
     "geom:latitude":2.993306,
     "geom:longitude":45.568166,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SD.JO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308147,
-    "wof:geomhash":"9299143cb72a1dc5b8d39ebf115b468e",
+    "wof:geomhash":"771240463e9c4425254ab3f384071c6b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108757861,
-    "wof:lastmodified":1566649564,
+    "wof:lastmodified":1695886425,
     "wof:name":"Jowhar",
     "wof:parent_id":85677275,
     "wof:placetype":"county",

--- a/data/110/875/786/3/1108757863.geojson
+++ b/data/110/875/786/3/1108757863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.255618,
-    "geom:area_square_m":3155189103.02507,
+    "geom:area_square_m":3155189391.574106,
     "geom:bbox":"45.183302,3.200655,46.086515,3.572561",
     "geom:latitude":3.403749,
     "geom:longitude":45.612717,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"SO.HI.JQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308148,
-    "wof:geomhash":"fc9fe6562d4358dc10c15da5b0ceb202",
+    "wof:geomhash":"b7e588adfb96b9512399c9cd36442c2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757863,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886482,
     "wof:name":"Jalalaqsi",
     "wof:parent_id":85677269,
     "wof:placetype":"county",

--- a/data/110/875/786/5/1108757865.geojson
+++ b/data/110/875/786/5/1108757865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165536,
-    "geom:area_square_m":2031452439.473286,
+    "geom:area_square_m":2031452439.473525,
     "geom:bbox":"46.8894074696,6.73450893679,47.5283170093,7.36062962724",
     "geom:latitude":7.039147,
     "geom:longitude":47.217747,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"SO.MU.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308150,
-    "wof:geomhash":"f16a5e9e41447c7562d35f4e9f9a129d",
+    "wof:geomhash":"2d85a562bda2fcdeea301831bc6115bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757865,
-    "wof:lastmodified":1566649564,
+    "wof:lastmodified":1695886425,
     "wof:name":"Galdogob",
     "wof:parent_id":85677279,
     "wof:placetype":"county",

--- a/data/110/875/787/9/1108757879.geojson
+++ b/data/110/875/787/9/1108757879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.532995,
-    "geom:area_square_m":18694929742.181293,
+    "geom:area_square_m":18694930811.866016,
     "geom:bbox":"49.039135,8.337058,50.090204,10.559783",
     "geom:latitude":9.502567,
     "geom:longitude":49.507468,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BR.QR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308156,
-    "wof:geomhash":"230997e4d35e3b92c80ff8693e7c2e0d",
+    "wof:geomhash":"9cbd9dcd3cb24d643ae741fc9434fe19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108757879,
-    "wof:lastmodified":1636497585,
+    "wof:lastmodified":1695886738,
     "wof:name":"Qardho",
     "wof:parent_id":85677235,
     "wof:placetype":"county",

--- a/data/110/875/788/1/1108757881.geojson
+++ b/data/110/875/788/1/1108757881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.705592,
-    "geom:area_square_m":8629544554.314579,
+    "geom:area_square_m":8629544253.342136,
     "geom:bbox":"48.054825,8.020609,49.301497,9.135598",
     "geom:latitude":8.470265,
     "geom:longitude":48.786582,
@@ -165,9 +165,10 @@
     "wof:concordances":{
         "hasc:id":"SO.NU.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308157,
-    "wof:geomhash":"767f7c55f79a8285b8c24cf74a916e74",
+    "wof:geomhash":"664f1194747223173cfdb0065bd87671",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":1108757881,
-    "wof:lastmodified":1636497585,
+    "wof:lastmodified":1695886739,
     "wof:name":"Garoowe",
     "wof:parent_id":85677283,
     "wof:placetype":"county",

--- a/data/110/875/788/3/1108757883.geojson
+++ b/data/110/875/788/3/1108757883.geojson
@@ -126,7 +126,7 @@
         }
     ],
     "wof:id":1108757883,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886739,
     "wof:name":"Marka",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/788/5/1108757885.geojson
+++ b/data/110/875/788/5/1108757885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.261885,
-    "geom:area_square_m":3236407620.19037,
+    "geom:area_square_m":3236407418.419683,
     "geom:bbox":"43.908926,1.670837,44.840362,2.240943",
     "geom:latitude":1.935267,
     "geom:longitude":44.448959,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SH.QO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308160,
-    "wof:geomhash":"366f4bc135b05deb325021505f50f133",
+    "wof:geomhash":"1da980c6f6b31e5646d3630c02941689",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757885,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886482,
     "wof:name":"Qoryooley",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/788/7/1108757887.geojson
+++ b/data/110/875/788/7/1108757887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207619,
-    "geom:area_square_m":2566150115.301944,
+    "geom:area_square_m":2566150174.617635,
     "geom:bbox":"43.590036,1.441371,44.507838,1.891689",
     "geom:latitude":1.6748,
     "geom:longitude":44.066103,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SH.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308162,
-    "wof:geomhash":"e7bf2ce44907c94ddf5deb82c2f5e53a",
+    "wof:geomhash":"4295fadd62f8842da7c84bc5f851f40c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757887,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886482,
     "wof:name":"Kurtunwaarey",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/789/1/1108757891.geojson
+++ b/data/110/875/789/1/1108757891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.463255,
-    "geom:area_square_m":18076002961.303928,
+    "geom:area_square_m":18076002887.084084,
     "geom:bbox":"43.201288,1.628523,44.690838,3.341328",
     "geom:latitude":2.485723,
     "geom:longitude":44.006617,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BY.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308163,
-    "wof:geomhash":"28cc246e57da6036a9f3fcbc501d5914",
+    "wof:geomhash":"688d6499f5208e29866e76220dec0254",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757891,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886480,
     "wof:name":"Buur Hakaba",
     "wof:parent_id":85677245,
     "wof:placetype":"county",

--- a/data/110/875/789/3/1108757893.geojson
+++ b/data/110/875/789/3/1108757893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.486789,
-    "geom:area_square_m":6017463703.343999,
+    "geom:area_square_m":6017463907.373343,
     "geom:bbox":"42.982681,0.937244,44.14731,1.764708",
     "geom:latitude":1.383572,
     "geom:longitude":43.519833,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308164,
-    "wof:geomhash":"ce1590dd59678f5a3fe61cecdb65e6f9",
+    "wof:geomhash":"4064b43271b3e01949e16e15d20dbd1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757893,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886482,
     "wof:name":"Sablaale",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/789/7/1108757897.geojson
+++ b/data/110/875/789/7/1108757897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.538231,
-    "geom:area_square_m":6640315104.500122,
+    "geom:area_square_m":6640315572.143937,
     "geom:bbox":"44.282248,3.250123,44.800217,4.433012",
     "geom:latitude":3.835358,
     "geom:longitude":44.5292,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BK.TI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308167,
-    "wof:geomhash":"aa76e5b7949bf7f111d1f44b11e20941",
+    "wof:geomhash":"9327fbb162baf8bc7dae59d6af85ea9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757897,
-    "wof:lastmodified":1627522788,
+    "wof:lastmodified":1695886484,
     "wof:name":"Tayeeglow",
     "wof:parent_id":85677241,
     "wof:placetype":"county",

--- a/data/110/875/789/9/1108757899.geojson
+++ b/data/110/875/789/9/1108757899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.673842,
-    "geom:area_square_m":8313858886.483786,
+    "geom:area_square_m":8313858233.790163,
     "geom:bbox":"42.042772,3.259328,43.140065,4.30722",
     "geom:latitude":3.794195,
     "geom:longitude":42.697581,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GE.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308168,
-    "wof:geomhash":"17f5eb9bd052e0be0c3ad3a972ff0f52",
+    "wof:geomhash":"ab8f49914a91c5926eb0c71ca14befe5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108757899,
-    "wof:lastmodified":1636497586,
+    "wof:lastmodified":1695886739,
     "wof:name":"Luuq",
     "wof:parent_id":85677249,
     "wof:placetype":"county",

--- a/data/110/875/790/1/1108757901.geojson
+++ b/data/110/875/790/1/1108757901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228965,
-    "geom:area_square_m":2824918247.862854,
+    "geom:area_square_m":2824918081.85067,
     "geom:bbox":"43.093866,3.572653,43.795206,4.053003",
     "geom:latitude":3.81595,
     "geom:longitude":43.432616,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BK.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308169,
-    "wof:geomhash":"e6faf14e8e09ae2c6341fcf0b73966c9",
+    "wof:geomhash":"52283d415ff3a333bd1067a82dce7fff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757901,
-    "wof:lastmodified":1627522788,
+    "wof:lastmodified":1695886484,
     "wof:name":"Waajid",
     "wof:parent_id":85677241,
     "wof:placetype":"county",

--- a/data/110/875/790/3/1108757903.geojson
+++ b/data/110/875/790/3/1108757903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465127,
-    "geom:area_square_m":5744509676.69258,
+    "geom:area_square_m":5744509833.686212,
     "geom:bbox":"44.620319,2.237558,45.332784,3.27294",
     "geom:latitude":2.792056,
     "geom:longitude":44.906157,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.SH.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308171,
-    "wof:geomhash":"95e320c3f752e99bc2eba2fb28194bf4",
+    "wof:geomhash":"ada9a48a640a7f5feffa22910ab52b8f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757903,
-    "wof:lastmodified":1627522788,
+    "wof:lastmodified":1695886484,
     "wof:name":"Wanla Weyn",
     "wof:parent_id":85677259,
     "wof:placetype":"county",

--- a/data/110/875/790/9/1108757909.geojson
+++ b/data/110/875/790/9/1108757909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.442631,
-    "geom:area_square_m":5458571019.650403,
+    "geom:area_square_m":5458570325.841363,
     "geom:bbox":"43.28645,3.628347,44.292817,4.48021",
     "geom:latitude":4.188865,
     "geom:longitude":43.906132,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BK.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308174,
-    "wof:geomhash":"908fdbcf60f4016df423b54ccd17584b",
+    "wof:geomhash":"306252f80faf6a81bda923fafa8c3915",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757909,
-    "wof:lastmodified":1627522788,
+    "wof:lastmodified":1695886484,
     "wof:name":"Xudur",
     "wof:parent_id":85677241,
     "wof:placetype":"county",

--- a/data/110/875/791/1/1108757911.geojson
+++ b/data/110/875/791/1/1108757911.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108757911,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886482,
     "wof:name":"Rab Dhuure",
     "wof:parent_id":85677241,
     "wof:placetype":"county",

--- a/data/110/875/791/3/1108757913.geojson
+++ b/data/110/875/791/3/1108757913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313248,
-    "geom:area_square_m":3866377645.143908,
+    "geom:area_square_m":3866377068.779162,
     "geom:bbox":"41.317277,3.002798,42.100006,3.913649",
     "geom:latitude":3.436172,
     "geom:longitude":41.732635,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GE.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308176,
-    "wof:geomhash":"09c7e7efba41388b486e52a4a345ccb7",
+    "wof:geomhash":"958e96d0bbd5c24bd6574aea4ee4f88e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757913,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886481,
     "wof:name":"Belet Xaawo",
     "wof:parent_id":85677249,
     "wof:placetype":"county",

--- a/data/110/875/791/9/1108757919.geojson
+++ b/data/110/875/791/9/1108757919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.890684,
-    "geom:area_square_m":10927391989.719864,
+    "geom:area_square_m":10927392479.87837,
     "geom:bbox":"48.490264,6.59558,49.648025,7.711613",
     "geom:latitude":7.163238,
     "geom:longitude":48.999076,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.MU.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308183,
-    "wof:geomhash":"438cb275072eae19a2b1e632ca546a79",
+    "wof:geomhash":"635412e625ea86ac69348a1c57bcd090",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757919,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886483,
     "wof:name":"Jariiban",
     "wof:parent_id":85677279,
     "wof:placetype":"county",

--- a/data/110/875/792/1/1108757921.geojson
+++ b/data/110/875/792/1/1108757921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.78926,
-    "geom:area_square_m":9668938252.475878,
+    "geom:area_square_m":9668937924.606028,
     "geom:bbox":"47.570024,7.411882,49.189113,8.21034",
     "geom:latitude":7.802108,
     "geom:longitude":48.401765,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"SO.NU.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308184,
-    "wof:geomhash":"8e6c264512d2dd84a27a59e7f6a387f8",
+    "wof:geomhash":"01b410d5794bfca6210d917c7a925781",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757921,
-    "wof:lastmodified":1627522785,
+    "wof:lastmodified":1695886481,
     "wof:name":"Burtinle",
     "wof:parent_id":85677283,
     "wof:placetype":"county",

--- a/data/110/875/792/3/1108757923.geojson
+++ b/data/110/875/792/3/1108757923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266701,
-    "geom:area_square_m":3293827298.335624,
+    "geom:area_square_m":3293827089.263794,
     "geom:bbox":"42.517341,2.570517,43.122758,3.082556",
     "geom:latitude":2.815078,
     "geom:longitude":42.840253,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BY.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308185,
-    "wof:geomhash":"de609bc2ed5591f0002d87a63e5c0a4b",
+    "wof:geomhash":"053746cb1a6cb1246b5ffea200d50ac3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757923,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886483,
     "wof:name":"Qansax Dheere",
     "wof:parent_id":85677245,
     "wof:placetype":"county",

--- a/data/110/875/792/7/1108757927.geojson
+++ b/data/110/875/792/7/1108757927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.796738,
-    "geom:area_square_m":9850437740.637787,
+    "geom:area_square_m":9850437558.052387,
     "geom:bbox":"40.994373,-1.661965,41.974609,-0.149231",
     "geom:latitude":-0.854791,
     "geom:longitude":41.42708,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JH.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308186,
-    "wof:geomhash":"b447451ea5c3049bff7da2fa1a3ab75d",
+    "wof:geomhash":"80b93084c9ccb1f13dfd1bca61c4689b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757927,
-    "wof:lastmodified":1627522784,
+    "wof:lastmodified":1695886480,
     "wof:name":"Badhaadhe",
     "wof:parent_id":85677287,
     "wof:placetype":"county",

--- a/data/110/875/792/9/1108757929.geojson
+++ b/data/110/875/792/9/1108757929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134704,
-    "geom:area_square_m":1661569958.504462,
+    "geom:area_square_m":1661570156.976463,
     "geom:bbox":"41.858673,3.791923,42.399719,4.195292",
     "geom:latitude":4.005029,
     "geom:longitude":42.142483,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"SO.GE.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308187,
-    "wof:geomhash":"5c716e841cd365667dd77ab239a67a78",
+    "wof:geomhash":"418a6e5e1852d1d59e534f8da81e8065",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757929,
-    "wof:lastmodified":1627522786,
+    "wof:lastmodified":1695886482,
     "wof:name":"Doolow",
     "wof:parent_id":85677249,
     "wof:placetype":"county",

--- a/data/110/875/793/1/1108757931.geojson
+++ b/data/110/875/793/1/1108757931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.614991,
-    "geom:area_square_m":7463165253.587303,
+    "geom:area_square_m":7463165253.588052,
     "geom:bbox":"49.5867524193,10.5121368845,50.5495535463,11.6313040233",
     "geom:latitude":11.059622,
     "geom:longitude":50.088677,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"SO.BR.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308188,
-    "wof:geomhash":"a3040b097077f673ddcab19606dd4e4d",
+    "wof:geomhash":"488df5dbdfc6e5f8266baaecdd2814fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108757931,
-    "wof:lastmodified":1566649561,
+    "wof:lastmodified":1695886425,
     "wof:name":"Qandala",
     "wof:parent_id":85677235,
     "wof:placetype":"county",

--- a/data/110/875/793/3/1108757933.geojson
+++ b/data/110/875/793/3/1108757933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.654747,
-    "geom:area_square_m":8092765468.042672,
+    "geom:area_square_m":8092765018.170272,
     "geom:bbox":"41.423125,1.262044,42.946625,1.953096",
     "geom:latitude":1.62885,
     "geom:longitude":42.062417,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SO.JD.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SO",
     "wof:created":1481308189,
-    "wof:geomhash":"61c33512a44fa7d6c77aba21c5908a24",
+    "wof:geomhash":"d292a5e5cfb123ee671284dead7121e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108757933,
-    "wof:lastmodified":1627522787,
+    "wof:lastmodified":1695886483,
     "wof:name":"Saakow",
     "wof:parent_id":85677253,
     "wof:placetype":"county",

--- a/data/856/323/79/85632379.geojson
+++ b/data/856/323/79/85632379.geojson
@@ -1153,6 +1153,7 @@
         "hasc:id":"SO",
         "icao:code":"6O",
         "ioc:id":"SOM",
+        "iso:code":"SO",
         "itu:id":"SOM",
         "loc:id":"n79060840",
         "m49:code":"706",
@@ -1166,6 +1167,7 @@
         "wk:page":"Somalia",
         "wmo:id":"SI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:country_alpha3":"SOM",
     "wof:geom_alt":[
@@ -1188,7 +1190,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1694639522,
+    "wof:lastmodified":1695881178,
     "wof:name":"Somalia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/772/35/85677235.geojson
+++ b/data/856/772/35/85677235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.630801,
-    "geom:area_square_m":68513094340.33075,
+    "geom:area_square_m":68513094557.107536,
     "geom:bbox":"48.922487,8.324998,51.415417,11.986111",
     "geom:latitude":10.220501,
     "geom:longitude":50.050531,
@@ -291,17 +291,19 @@
         "gn:id":64661,
         "gp:id":2347008,
         "hasc:id":"SO.BR",
+        "iso:code":"SO-BR",
         "iso:id":"SO-BR",
         "qs_pg:id":205939,
         "unlc:id":"SO-BR",
         "wd:id":"Q729170",
         "wk:page":"Bari, Somalia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae95270bbf5ae967bd9579825eebc992",
+    "wof:geomhash":"bf2e00e7bffd18b926e7bffbf4ee039b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865911,
+    "wof:lastmodified":1695884854,
     "wof:name":"Bari",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/41/85677241.geojson
+++ b/data/856/772/41/85677241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.099949,
-    "geom:area_square_m":25895673072.787182,
+    "geom:area_square_m":25895672899.810482,
     "geom:bbox":"42.880434,3.250123,44.800217,4.959288",
     "geom:latitude":4.207295,
     "geom:longitude":43.952677,
@@ -289,17 +289,19 @@
         "gn:id":64982,
         "gp:id":2347006,
         "hasc:id":"SO.BK",
+        "iso:code":"SO-BK",
         "iso:id":"SO-BK",
         "qs_pg:id":191397,
         "unlc:id":"SO-BK",
         "wd:id":"Q282471",
         "wk:page":"Bakool"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4fc3f3c09dc97c021beb6db29237395d",
+    "wof:geomhash":"41f02f51d2d3d77d9fd4a70553352122",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -316,7 +318,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865914,
+    "wof:lastmodified":1695884855,
     "wof:name":"Bakool",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/45/85677245.geojson
+++ b/data/856/772/45/85677245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.569857,
-    "geom:area_square_m":44092568444.746719,
+    "geom:area_square_m":44092568335.1511,
     "geom:bbox":"42.400823,1.461489,44.690838,3.92192",
     "geom:latitude":2.654661,
     "geom:longitude":43.56683,
@@ -286,17 +286,19 @@
         "gn:id":64538,
         "gp:id":2347009,
         "hasc:id":"SO.BY",
+        "iso:code":"SO-BY",
         "iso:id":"SO-BY",
         "qs_pg:id":1168750,
         "unlc:id":"SO-BY",
         "wd:id":"Q812064",
         "wk:page":"Bay, Somalia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d0406231aa29bfd15a444b605899435",
+    "wof:geomhash":"e64323fa317bb600de502075ee24013d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +315,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865912,
+    "wof:lastmodified":1695884855,
     "wof:name":"Bay",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/49/85677249.geojson
+++ b/data/856/772/49/85677249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.672798,
-    "geom:area_square_m":45352998110.765381,
+    "geom:area_square_m":45352998110.76506,
     "geom:bbox":"40.994374,1.231853,43.140065,4.30722",
     "geom:latitude":2.898727,
     "geom:longitude":41.981347,
@@ -292,17 +292,19 @@
         "gn:id":58802,
         "gp:id":2347011,
         "hasc:id":"SO.GE",
+        "iso:code":"SO-GE",
         "iso:id":"SO-GE",
         "qs_pg:id":988724,
         "unlc:id":"SO-GE ",
         "wd:id":"Q856719",
         "wk:page":"Gedo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d848ad35587fa998c2818813f5438e3a",
+    "wof:geomhash":"fb672e6bb8f8b1e9644d162900cc7095",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865915,
+    "wof:lastmodified":1695884855,
     "wof:name":"Gedo",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/53/85677253.geojson
+++ b/data/856/772/53/85677253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.529126,
-    "geom:area_square_m":18903035975.30825,
+    "geom:area_square_m":18903035779.857185,
     "geom:bbox":"41.423125,0.311395,43.520826,1.953096",
     "geom:latitude":1.227895,
     "geom:longitude":42.538445,
@@ -286,17 +286,19 @@
         "gn:id":56084,
         "gp:id":2347013,
         "hasc:id":"SO.JD",
+        "iso:code":"SO-JD",
         "iso:id":"SO-JD",
         "qs_pg:id":1135328,
         "unlc:id":"SO-JD",
         "wd:id":"Q1046324",
         "wk:page":"Middle Juba"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0245dee30535e3597f59a3184679a55",
+    "wof:geomhash":"39d7200956f460ce0f4a3acea7260a05",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +315,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865913,
+    "wof:lastmodified":1695884358,
     "wof:name":"Juba Dhexe",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/59/85677259.geojson
+++ b/data/856/772/59/85677259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.093724,
-    "geom:area_square_m":25873519396.118347,
+    "geom:area_square_m":25873518982.049759,
     "geom:bbox":"42.982681,0.675406,45.388845,3.27294",
     "geom:latitude":1.904989,
     "geom:longitude":44.327114,
@@ -293,17 +293,19 @@
         "gn:id":51966,
         "gp:id":2347019,
         "hasc:id":"SO.SH",
+        "iso:code":"SO-SH",
         "iso:id":"SO-SH",
         "qs_pg:id":984096,
         "unlc:id":"SO-SH",
         "wd:id":"Q877028",
         "wk:page":"Lower Shebelle"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a407dffb05af903fc44ad844fe6cf1f7",
+    "wof:geomhash":"a7265b36b99d7b0797b035de1b321fcd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865911,
+    "wof:lastmodified":1695884854,
     "wof:name":"Shabeellaha Hoose",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/63/85677263.geojson
+++ b/data/856/772/63/85677263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017767,
-    "geom:area_square_m":219537278.373639,
+    "geom:area_square_m":219537278.37362,
     "geom:bbox":"45.279931,1.999021,45.608667,2.185002",
     "geom:latitude":2.111423,
     "geom:longitude":45.426577,
@@ -295,12 +295,14 @@
         "gn:id":64833,
         "gp:id":2347007,
         "hasc:id":"SO.BN",
+        "iso:code":"SO-BN",
         "iso:id":"SO-BN",
         "qs_pg:id":894982,
         "unlc:id":"SO-BN",
         "wd:id":"Q806070",
         "wk:page":"Banaadir"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890449737,
         1108757805
@@ -309,7 +311,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d7dd3fc21f19c46cb79250cd4f5e25f",
+    "wof:geomhash":"9419e8ac0b64c59b24a7fcf0da8a5ccc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865913,
+    "wof:lastmodified":1695884855,
     "wof:name":"Banaadir",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/67/85677267.geojson
+++ b/data/856/772/67/85677267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.026482,
-    "geom:area_square_m":49586158725.295616,
+    "geom:area_square_m":49586157792.236519,
     "geom:bbox":"45.51676,3.470957,47.827847,6.537821",
     "geom:latitude":5.110314,
     "geom:longitude":46.773109,
@@ -295,17 +295,19 @@
         "gn:id":59362,
         "gp:id":2347010,
         "hasc:id":"SO.GA",
+        "iso:code":"SO-GA",
         "iso:id":"SO-GA",
         "qs_pg:id":229388,
         "unlc:id":"SO-GA",
         "wd:id":"Q876772",
         "wk:page":"Galguduud"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0cbb34d6d305c99d9882942e25a0aa0",
+    "wof:geomhash":"f219eb1bcb526d3619d06d3dc4ff9dbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -322,7 +324,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865912,
+    "wof:lastmodified":1695884855,
     "wof:name":"Galguduud",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/69/85677269.geojson
+++ b/data/856/772/69/85677269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.778646,
-    "geom:area_square_m":34263923014.774281,
+    "geom:area_square_m":34263923047.878727,
     "geom:bbox":"44.59565,3.200655,46.401171,5.490944",
     "geom:latitude":4.217665,
     "geom:longitude":45.472952,
@@ -302,17 +302,19 @@
         "gn:id":57060,
         "gp:id":2347012,
         "hasc:id":"SO.HI",
+        "iso:code":"SO-HI",
         "iso:id":"SO-HI",
         "qs_pg:id":894983,
         "unlc:id":"SO-HI",
         "wd:id":"Q660040",
         "wk:page":"Hiran, Somalia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"98121f8de4a7699e3742dc4542c446c5",
+    "wof:geomhash":"285eadcae6997cd0b2d74c694f2a31f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865911,
+    "wof:lastmodified":1695884855,
     "wof:name":"Hiiraan",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/75/85677275.geojson
+++ b/data/856/772/75/85677275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.518104,
-    "geom:area_square_m":18745000435.842331,
+    "geom:area_square_m":18745000258.665653,
     "geom:bbox":"45.075124,2.151314,47.036371,3.891415",
     "geom:latitude":3.028237,
     "geom:longitude":46.014209,
@@ -297,17 +297,19 @@
         "gn:id":51967,
         "gp:id":2347018,
         "hasc:id":"SO.SD",
+        "iso:code":"SO-SD",
         "iso:id":"SO-SD",
         "qs_pg:id":229383,
         "unlc:id":"SO-SD",
         "wd:id":"Q678435",
         "wk:page":"Middle Shebelle"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8cfa4e909fab5b899e0fb26e9525b50",
+    "wof:geomhash":"b5a90a35b03d269c820e960e8f2ea1fc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865913,
+    "wof:lastmodified":1695884855,
     "wof:name":"Shabeellaha Dhexe",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/79/85677279.geojson
+++ b/data/856/772/79/85677279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.791542,
-    "geom:area_square_m":58876006942.304031,
+    "geom:area_square_m":58876008290.295563,
     "geom:bbox":"46.534873,4.334106,49.648025,7.711613",
     "geom:latitude":6.378272,
     "geom:longitude":48.148997,
@@ -299,17 +299,19 @@
         "gn:id":53707,
         "gp:id":2347015,
         "hasc:id":"SO.MU",
+        "iso:code":"SO-MU",
         "iso:id":"SO-MU",
         "qs_pg:id":209014,
         "unlc:id":"SO-MU",
         "wd:id":"Q877034",
         "wk:page":"Mudug"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2231a201a1ab26669a0d7009170e06d",
+    "wof:geomhash":"5e674bc5dcecc8ec6456e3a974d99866",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865914,
+    "wof:lastmodified":1695884855,
     "wof:name":"Mudug",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/83/85677283.geojson
+++ b/data/856/772/83/85677283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.255092,
-    "geom:area_square_m":27605228525.221764,
+    "geom:area_square_m":27605227510.02866,
     "geom:bbox":"47.570024,7.40489,50.172269,9.135598",
     "geom:latitude":8.10964,
     "geom:longitude":48.914235,
@@ -299,17 +299,19 @@
         "gn:id":53477,
         "gp:id":2347016,
         "hasc:id":"SO.NU",
+        "iso:code":"SO-NU",
         "iso:id":"SO-NU",
         "qs_pg:id":507468,
         "unlc:id":"SO-NU",
         "wd:id":"Q1046329",
         "wk:page":"Nugal, Somalia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a77230ee0400285cfba91474ca024f4d",
+    "wof:geomhash":"9f762cb609de87af46e39046b9cb1d1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865914,
+    "wof:lastmodified":1695884855,
     "wof:name":"Nugaal",
     "wof:parent_id":85632379,
     "wof:placetype":"region",

--- a/data/856/772/87/85677287.geojson
+++ b/data/856/772/87/85677287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.900878,
-    "geom:area_square_m":48231402455.226051,
+    "geom:area_square_m":48231401929.263535,
     "geom:bbox":"40.994373,-1.661965,43.186983,1.32043",
     "geom:latitude":0.086642,
     "geom:longitude":41.801075,
@@ -287,17 +287,19 @@
         "gn:id":56083,
         "gp:id":2347014,
         "hasc:id":"SO.JH",
+        "iso:code":"SO-JH",
         "iso:id":"SO-JH",
         "qs_pg:id":268611,
         "unlc:id":"SO-JH",
         "wd:id":"Q877042",
         "wk:page":"Lower Juba"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a01829373cb900491030c55b9bfc711",
+    "wof:geomhash":"5793ec93b7e7d535575ddf6200dea545",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690865912,
+    "wof:lastmodified":1695884855,
     "wof:name":"Jubbada Hoose",
     "wof:parent_id":85632379,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.